### PR TITLE
Installation instructions: fix tar missing z flag on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ You can download the latest release from the [Releases page](https://github.com/
 x86:
 
 ```bash
-$ curl -sL https://github.com/tidewave-ai/mcp_proxy_rust/releases/latest/download/mcp-proxy-x86_64-unknown-linux-musl.tar.gz | tar xv
+$ curl -sL https://github.com/tidewave-ai/mcp_proxy_rust/releases/latest/download/mcp-proxy-x86_64-unknown-linux-musl.tar.gz | tar zxv
 ```
 
 arm64 / aarch64:
 
 ```bash
-$ curl -sL https://github.com/tidewave-ai/mcp_proxy_rust/releases/latest/download/mcp-proxy-aarch64-unknown-linux-musl.tar.gz | tar xv
+$ curl -sL https://github.com/tidewave-ai/mcp_proxy_rust/releases/latest/download/mcp-proxy-aarch64-unknown-linux-musl.tar.gz | tar zxv
 ```
 
 ### Windows


### PR DESCRIPTION
On Linux, it seems the `z` flag is required for `tar` to correctly extract the binary download from GitHub releases.

Failing example without `z`:
```bash
$ curl -sL https://github.com/tidewave-ai/mcp_proxy_rust/releases/latest/download/mcp-proxy-x86_64-unknown-linux-musl.tar.gz | tar xv
tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
```

Working example with `z`:
```bash
$ curl -sL https://github.com/tidewave-ai/mcp_proxy_rust/releases/latest/download/mcp-proxy-x86_64-unknown-linux-musl.tar.gz | tar zxv
mcp-proxy
```

Why? Doing `man tar` on macOS:
```man
-z, --gunzip, --gzip
        (c mode only) Compress the resulting archive with gzip(1).  In extract or list
        modes, this option is ignored.  Note that this tar implementation recognizes 
        gzip compression automatically when reading archives.
```

`man tar` on Linux:
```man
-z, --gzip, --gunzip, --ungzip
       Filter the archive through gzip(1).
``` 
