### PR TITLE
support a flag to rewrite protocol versions on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ A standalone binary for connecting STDIO based MCP clients to HTTP (SSE) based M
 Note: the proxy supports both SSE according to the `2024-11-05` as well as streamable HTTP according to the `2025-03-26` specification.
 It may happen though that the connecting client does **not** support the version sent by the server.
 
+## Protocol Version Compatibility
+
+The proxy can optionally handle protocol version compatibility between clients and servers. When enabled with the `--rewrite-protocol-version` flag, the proxy will rewrite protocol version `2025-03-26` to `2024-11-05` in server initialize responses to ensure compatibility with older clients.
+
+This feature is opt-in and must be explicitly enabled using the command line flag.
+
 ## Installation
 
 The latest releases are available on the [releases page](https://github.com/tidewave-ai/mcp_proxy_rust/releases).
@@ -106,3 +112,4 @@ If you have an SSE MCP server available at `http://localhost:4000/tidewave/mcp`,
 Other supported flags:
 
 * `--max-disconnected-time` the maximum amount of time for trying to reconnect while disconnected. When not set, defaults to infinity.
+* `--rewrite-protocol-version` enable protocol version rewriting (2025-03-26 -> 2024-11-05) for client compatibility.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,4 +18,8 @@ pub struct Args {
     /// Initial retry interval in seconds. Default is 5 seconds
     #[arg(long, default_value = "5")]
     pub initial_retry_interval: u64,
+
+    /// Enable protocol version rewriting (2025-03-26 -> 2024-11-05)
+    #[arg(long)]
+    pub rewrite_protocol_version: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ async fn main() -> Result<()> {
     let (timer_tx, mut timer_rx) = tokio::sync::mpsc::channel(10);
 
     // Initialize application state
-    let mut app_state = AppState::new(sse_url.clone(), args.max_disconnected_time);
+    let mut app_state = AppState::new(sse_url.clone(), args.max_disconnected_time, args.rewrite_protocol_version);
     // Pass channel senders to state
     app_state.reconnect_tx = Some(reconnect_tx.clone());
     app_state.timer_tx = Some(timer_tx.clone());


### PR DESCRIPTION
Many consumers do not support the latest version of the protocol explicitly, but implicitly/via the proxy they do. This lets users get around the errors about protocol versions not being supported.