### PR TITLE
use fork to handle transport errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,9 +1404,8 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f521fbd040eba82684b17d787d423f43afb6e97974029b51f679157a589592a"
+version = "0.8.1"
+source = "git+https://github.com/SteffenDE/mcp-rust-sdk.git?branch=sd-bad-request#75abb05b7d3eba574de137b8876a91f2ad5173cf"
 dependencies = [
  "axum",
  "base64",
@@ -1437,9 +1436,8 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c162bf8a2846f70464ded6dda6430b60d1e2fb4b0e371f0906e39f63916641b9"
+version = "0.8.1"
+source = "git+https://github.com/SteffenDE/mcp-rust-sdk.git?branch=sd-bad-request#75abb05b7d3eba574de137b8876a91f2ad5173cf"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.2"
 edition = "2024"
 
 [dependencies]
-rmcp = { version = "0.6.1", features = [
+rmcp = { git = "https://github.com/SteffenDE/mcp-rust-sdk.git", branch = "sd-bad-request", features = [
     "server",
     "client",
     "reqwest",
@@ -29,7 +29,7 @@ version = "0.9"
 features = ["vendored"]
 
 [dev-dependencies]
-rmcp = { version = "0.6.1", features = [
+rmcp = { git = "https://github.com/SteffenDE/mcp-rust-sdk.git", branch = "sd-bad-request", features = [
     "server",
     "client",
     "reqwest",


### PR DESCRIPTION
Uses https://github.com/modelcontextprotocol/rust-sdk/pull/486.
Closes https://github.com/tidewave-ai/tidewave_phoenix/pull/197.